### PR TITLE
Update links.txt

### DIFF
--- a/src/links.txt
+++ b/src/links.txt
@@ -1220,6 +1220,7 @@ discrodapp.site
 discrodapp.xyz
 discrode-gift.club
 discrode-gift.com
+discrode-gifte.club
 discrodnitro.org
 discrodnitro.ru
 discrodnitro.site


### PR DESCRIPTION
- Add `discrode-gifte.club`.
- The URL is spread around with a trailing `/nitro` link. 
- Also not too sure why `zipsetgo.com` has been moved down a line in the overview? - nothing was changed other than adding the above URL.