### PR TITLE
Update links.txt

### DIFF
--- a/src/links.txt
+++ b/src/links.txt
@@ -796,7 +796,6 @@ discord.fit
 discord.foundation
 discord.fun
 discord.fyi
-discord.gift
 discord.givaeway.com
 discord.givaewey.com
 discord.givaeweys.com
@@ -1218,6 +1217,7 @@ discrodapp.com
 discrodapp.ru
 discrodapp.site
 discrodapp.xyz
+discrode-app.com
 discrode-gift.club
 discrode-gift.com
 discrode-gifte.club


### PR DESCRIPTION
This PR:
- adds the link from https://scammer.info/t/airdrop-discord-nitro-with-steam-scam-7-977-525-68-47/86156
- removes `discord[.]gift` as it seems to be a false positive