### PR TITLE
removed non-scam url

### DIFF
--- a/src/links.txt
+++ b/src/links.txt
@@ -3907,7 +3907,6 @@ free-nitro.org.ru
 free-nitro.ru
 free-nitro.ru.com
 free-nitro.space
-free-nitro.xyz
 free-nitroi.ru
 free-nitroos.ru
 free-nitros.ru


### PR DESCRIPTION
hi,
as i found out from a group of bot devs
"free-nitro.xyz" is NOT a scam url. in fact it teaches you about how to spot scam, etc.