### PR TITLE
Remove dis.cord.gift

### DIFF
--- a/src/links.txt
+++ b/src/links.txt
@@ -852,7 +852,6 @@ dirtyteenagers.com
 dis-kord.com
 dis-nitr.site
 dis-nittro.com
-dis.cord.gift
 dis.cord.gifts
 disacord.com
 disbordapp.com


### PR DESCRIPTION
dis.cord.gift is not a scam link, but rather a joke site: https://github.com/Erisa/dis.cord.gift

The code is open-source where it shows all what it does: https://github.com/Erisa/dis.cord.gift/blob/main/_worker.js